### PR TITLE
Removing the MUST statement regarding the value of a combobox

### DIFF
--- a/index.html
+++ b/index.html
@@ -2296,14 +2296,6 @@
 				If the popup element supports <pref>aria-activedescendant</pref>, in lieu of moving focus, such keyboard mechanisms can control the value of <pref>aria-activedescendant</pref> on the <code>combobox</code> element.
 				When a descendant of the popup element is active, authors MAY set <pref>aria-activedescendant</pref> on the <code>combobox</code> to a value that refers to the active element within the popup while focus remains on the <code>combobox</code> element.
 				</p>
-				<p>
-				User agents MUST expose the value of elements with role <code>combobox</code> to <a>assistive technologies</a>.
-				The value of a <code>combobox</code> is represented by one of the following:
-				</p>
-				<ul>
-					<li>If the <code>combobox</code> element is a host language element that provides a value, such as an HTML <code>input</code> element, the value of the combobox is the value of that element.</li>
-					<li>Otherwise, the value of the <code>combobox</code> is represented by its descendant elements and can be determined using the same method used to compute the name of a <rref>button</rref> from its descendant content.</li>
-				</ul>
 				<pre class="example highlight">
           &lt;label id="tag_label" for="tag_combo">Tag&lt;/label>
 		      &lt;input type="text" id="tag_combo"


### PR DESCRIPTION
Fixes https://github.com/w3c/aria/issues/1720. Removing the MUST statement about getting the value for a combobox because it includes logic to get a value. The method to get a value will be handled outside the ARIA spec, in either accName or Core-AAM. See the discussion at https://github.com/w3c/accname/issues/184/.

Closes #????

<!--- IF EDITORIAL or CHORE, delete the rest of this template -->

Describe Change Here!

# Issue/PR tracking
if not applicable state N/A

<!--- Check these once you have confirmed the related change is not necessary or created an issue/PR and added the link here -->

* [ ] Related Core AAM Issue/PR:
* [ ] Related AccName Issue/PR:
* [ ] Related APG Issue/PR:
* [ ] Any other dependent changes?

# Implementation tracking

* [ ] validator tests
* [ ] WPT tests: [LINK]()
* [ ] Browser implementations (link to issue or when done, link to commit):
   * WebKit: [ISSUE]()
   * Gecko: [ISSUE]()
   * Blink: [ISSUE]()
* [ ] Does this need AT implementations?
